### PR TITLE
Added error-tooltip to form options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 .sass-cache
 bower_components
 dist/styles
+dist/js/tooltip.js
 dist/js/templates.js
 dist/js/bootstrap-datepicker.js
 dist/js/dust-core.js

--- a/styles/sass/partials/_forms.scss
+++ b/styles/sass/partials/_forms.scss
@@ -153,4 +153,40 @@ label.error {
     font-size: .8rem;
     color: $error-color;
 }
+
+// Add this on the form if you want errors to show in a tooltip
+.error-tooltip {
+    position: relative;
+
+    label.error {
+        $height: 5px;
+        $width: 10px;
+
+        position: absolute;
+        z-index: 2000;
+        height: 1.2rem;
+        background: $error-color;
+        padding: .2rem;
+        color: $white;
+        margin-bottom: -1.1rem;
+        left: 0.3rem;
+        box-shadow: rgba(0, 0, 0, 0.38) 0 2px 0;
+
+        &:before {
+            width: 0;
+            height: 0;
+            border-style: solid;
+            border-width: 0 $width/2 $height;
+            border-color: rgba(0, 0, 0, 0) rgba(0, 0, 0, 0) $error-color;
+            content: "";
+            position: absolute;
+            top: 0;
+            margin-top: -$height;
+            left: 12px;
+        }
+    }
+}
+
 // scss-lint:enable QualifyingElement
+
+

--- a/styles/sass/partials/_standard-button.scss
+++ b/styles/sass/partials/_standard-button.scss
@@ -46,7 +46,8 @@ button,
         margin-left: 10px;
     }
 
-    &:disabled, &.disabled {
+    &:disabled,
+    &.disabled {
         color: $border-grey;
         background: $background-grey;
         border-color: $background-grey;


### PR DESCRIPTION
If you add the class error-tooltip, error labels
will show as a tooltip under their respective
fields when using the validation plugin.