### PR TITLE
Fixed dynamic-input loading bug

### DIFF
--- a/styles/sass/partials/_forms.scss
+++ b/styles/sass/partials/_forms.scss
@@ -71,8 +71,8 @@
         color: $red;
     }
 
-    &.loading:after,
-    &.loading:not(:focus):after {
+    &.di-loading:after,
+    &.di-loading:not(:focus):after {
         @include icon;
         content: "loading";
         color: $ashen-grey;


### PR DESCRIPTION
It shared its loading class with the one for
$.loading();