### PR TITLE
[FIX] Calendar icon on datepicker input clickable

### DIFF
--- a/styles/sass/_highlightjs.scss
+++ b/styles/sass/_highlightjs.scss
@@ -4,11 +4,27 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
 */
 
+$hljs-grey:                 #333;
+$hljs-javadoc:              #998;
+$hljs-ruby:                 #008080;
+$hljs-tex:                  #d14;
+$hljs-scss:                 #900;
+$hljs-tex-command:          #458;
+$hljs-django:               #000080;
+$hljs-regexp:               #009926;
+$hljs-prompt:               #990073;
+$hljs-built-in:             #0086b3;
+$hljs-cdata:                #999;
+$hljs-deletion:             #fdd;
+$hljs-addition:             #dfd;
+$hljs-change:               #0086b3;
+$hljs-chunk:                #aaa;
+
 .hljs {
   display: block;
   overflow-x: auto;
   padding: 10px;
-  color: #333;
+  color: $hljs-grey;
   background: $background-grey;
   -webkit-text-size-adjust: none;
 }
@@ -16,7 +32,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs-comment,
 .diff .hljs-header,
 .hljs-javadoc {
-  color: #998;
+  color: $hljs-javadoc;
   font-style: italic;
 }
 
@@ -27,14 +43,14 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs-subst,
 .hljs-request,
 .hljs-status {
-  color: #333;
+  color: $hljs-grey;
   font-weight: bold;
 }
 
 .hljs-number,
 .hljs-hexcolor,
 .ruby .hljs-constant {
-  color: #008080;
+  color: $hljs-ruby;
 }
 
 .hljs-string,
@@ -42,13 +58,13 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs-phpdoc,
 .hljs-dartdoc,
 .tex .hljs-formula {
-  color: #d14;
+  color: $hljs-tex;
 }
 
 .hljs-title,
 .hljs-id,
 .scss .hljs-preprocessor {
-  color: #900;
+  color: $hljs-scss;
   font-weight: bold;
 }
 
@@ -61,7 +77,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs-type,
 .vhdl .hljs-literal,
 .tex .hljs-command {
-  color: #458;
+  color: $hljs-tex-command;
   font-weight: bold;
 }
 
@@ -69,7 +85,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs-tag .hljs-title,
 .hljs-rules .hljs-property,
 .django .hljs-tag .hljs-keyword {
-  color: #000080;
+  color: $hljs-django;
   font-weight: normal;
   clear: both;
 }
@@ -77,11 +93,11 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs-attribute,
 .hljs-variable,
 .lisp .hljs-body {
-  color: #008080;
+  color: $hljs-ruby;
 }
 
 .hljs-regexp {
-  color: #009926;
+  color: $hljs-regexp;
 }
 
 .hljs-symbol,
@@ -91,11 +107,11 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .scheme .hljs-keyword,
 .tex .hljs-special,
 .hljs-prompt {
-  color: #990073;
+  color: $hljs-prompt;
 }
 
 .hljs-built_in {
-  color: #0086b3;
+  color: $hljs-built-in;
 }
 
 .hljs-preprocessor,
@@ -104,22 +120,22 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs-doctype,
 .hljs-shebang,
 .hljs-cdata {
-  color: #999;
+  color: $hljs-cdata;
   font-weight: bold;
 }
 
 .hljs-deletion {
-  background: #fdd;
+  background: $hljs-deletion;
 }
 
 .hljs-addition {
-  background: #dfd;
+  background: $hljs-addition;
 }
 
 .diff .hljs-change {
-  background: #0086b3;
+  background: $hljs-change;
 }
 
 .hljs-chunk {
-  color: #aaa;
+  color: $hljs-chunk;
 }

--- a/styles/sass/knewcons.scss
+++ b/styles/sass/knewcons.scss
@@ -11,11 +11,11 @@
 }
 
 %knewcon {
-    font-family: "knewcons" !important;
-    font-style: normal !important;
-    font-weight: normal !important;
-    font-variant: normal !important;
-    text-transform: none !important;
+    font-family: "knewcons";
+    font-style: normal;
+    font-weight: normal;
+    font-variant: normal;
+    text-transform: none;
     speak: none;
     line-height: 1;
     -webkit-font-smoothing: antialiased;

--- a/styles/sass/partials/_datepicker.scss
+++ b/styles/sass/partials/_datepicker.scss
@@ -143,19 +143,19 @@
 .datepicker tr td {
   &.day:hover,
   &.day.focused {
-    background: #eee;
+    background: $background-grey;
     cursor: pointer;
   }
 
   &.old,
   &.new {
-    color: #999;
+    color: $ashen-grey;
   }
 
   &.disabled,
   &.disabled:hover {
     background: none;
-    color: #999;
+    color: $ashen-grey;
     cursor: default;
   }
 
@@ -269,9 +269,9 @@
     background-color: $turquoise-tint;
   }
 
-  &.selected,  
-  &.selected:hover, 
-  &.selected.disabled,  
+  &.selected,
+  &.selected:hover,
+  &.selected.disabled,
   &.selected.disabled:hover {
     background-color: $default;
     background-image: none;
@@ -530,7 +530,7 @@
   -webkit-background-clip: padding-box;
   -moz-background-clip: padding;
   background-clip: padding-box;
-  color: #333;
+  color: $black-enough;
   font-size: 13px;
   line-height: 20px;
 }
@@ -568,9 +568,9 @@
   max-width: 100%;
   background-color: transparent;
   border-collapse: collapse;
-  border-spacing: 2px;  
+  border-spacing: 2px;
   box-sizing: content-box;
-  
+
   thead {
     display: table-header-group;
   }
@@ -606,7 +606,7 @@
 .datepicker td,
 .datepicker th {
   text-align: center;
-  height: 20px;  
+  height: 20px;
   width: 20px;
   padding: 4px 5px;
   -webkit-border-radius: 4px;
@@ -643,13 +643,13 @@
       border: 0;
       text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
     }
-    
+
     &.active:active,
     &.active:hover:active,
     &.active.active,
     &.active:hover.active {
       background-color: $dark-turquoise;
-    }    
+    }
 }
 
 .datepicker {

--- a/styles/sass/partials/_forms.scss
+++ b/styles/sass/partials/_forms.scss
@@ -115,13 +115,6 @@
     line-height: 2rem;
     height: 2rem;
 
-    &:not(:focus):before {
-        position: absolute;
-        font-family: "knewcons";
-        content: "\e00d";
-        right: .5rem;
-    }
-
     input {
         border-radius: 0;
         box-shadow: none;
@@ -132,6 +125,12 @@
             outline: none;
             border: 1px solid $turquoise;
         }
+    }
+
+    span {
+        position: absolute;
+        right: 0.25em;
+        top: 0.15em;
     }
 }
 
@@ -187,5 +186,3 @@ label.error {
 }
 
 // scss-lint:enable QualifyingElement
-
-

--- a/templates/_sg/components/datepicker.dust
+++ b/templates/_sg/components/datepicker.dust
@@ -1,6 +1,6 @@
 <div class="input-date date" id="dp1">
     <input type="text" placeholder="mm/dd/yyyy" class="form-control">
-    <span class="add-on"></span>
+    <span class="add-on"><i class="icon-calendar"></i></span>
 </div>
 
 <script>


### PR DESCRIPTION
Most of SCSS changes are to be able to pass scss-lint.
The calendar icon on datepicker's input field is not on a pseudo-element (which are not clickable) but rather a separate div within the datepicker container.