### PR TITLE
[CTEACH-467] Decrease z-index of the loader

### DIFF
--- a/styles/sass/partials/_loading.scss
+++ b/styles/sass/partials/_loading.scss
@@ -15,7 +15,7 @@
         top: 0;
         left: 0;
         display: block;
-        z-index: 2000;
+        z-index: 100;
     }
 
     &:after {
@@ -32,7 +32,7 @@
         right: 0;
         margin: auto;
         color: rgb(27, 172, 182);
-        z-index: 2010;
+        z-index: 101;
     }
 }
 


### PR DESCRIPTION
The z-index of the loader was more than header and
modal.

Signed-off-by: Sharanya Venkat <sharanya@knewton.com>