### PR TITLE
[CTEACH-584] Dropdown arrows launch the dropdown

### DIFF
--- a/styles/sass/partials/_dropdown.scss
+++ b/styles/sass/partials/_dropdown.scss
@@ -25,6 +25,7 @@
         height: 8px;
         top: 15px;
         right: 18px;
+        pointer-events: none;
         background: url("../images/dropdown-arrow.png") no-repeat;
     }
 }


### PR DESCRIPTION
Set pointer-events to none. The element is not
the target of mouse events.
In these circumstances, mouse events will
trigger event listeners on this parent element.

Signed-off-by: Sharanya Venkat <sharanya@knewton.com>