### PR TITLE
Remove popover style imports

### DIFF
--- a/styles/sass/styleguide.scss
+++ b/styles/sass/styleguide.scss
@@ -8,7 +8,6 @@
 @import "bootstrap/dropdowns";
 @import "bootstrap/modals";
 @import "bootstrap/close";
-@import "bootstrap/popovers";
 @import "bootstrap/tooltip";
 @import "bootstrap/carousel";
 @import "bootstrap/panels";


### PR DESCRIPTION
Popover are not used and I want to use the popover class.